### PR TITLE
Add a newline before the resources line

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Force setuptools-scm version from release tag
+        if: github.event_name == 'release'
+        run: |
+          tag="${GITHUB_REF##*/}"
+          tag="${tag#v}"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${tag}" >> $GITHUB_ENV
+
       - uses: hynek/build-and-inspect-python-package@v2
 
   publish:

--- a/htcdaskgateway/cluster.py
+++ b/htcdaskgateway/cluster.py
@@ -91,7 +91,7 @@ class HTCGatewayCluster(GatewayCluster):
             f.write(security.tls_key)
 
         # Prepare JDL
-        resources = f" request_memory = {self.memory} \n request_cpus = {self.cpus}"
+        resources = f"\n request_memory = {self.memory} \n request_cpus = {self.cpus}"
         jdl = (
             """executable = start.sh
 arguments = """


### PR DESCRIPTION
# Problem
The memory setting is being ignored because there is no newline between the `log` entry and the `memory` entry in the jdl.

Adding a newline to the string